### PR TITLE
Checking if file in cache is stale

### DIFF
--- a/app/controllers/file.js
+++ b/app/controllers/file.js
@@ -12,7 +12,6 @@ const FileController = function(url, header) {
   this.header = header;
   this.fileName = fileSystem.getFileName(this.url);
   this.path = fileSystem.getPath(this.url);
-  this.updatedDuration = 1200000;
 };
 
 util.inherits(FileController, EventEmitter);
@@ -77,12 +76,12 @@ FileController.prototype.getTimestampData = function(cb) {
   });
 };
 
-FileController.prototype.isStale = function(cb) {
+FileController.prototype.isStale = function(updateDuration, cb) {
   this.getTimestampData((err, timestamp) => {
     if (err) return cb(err);
 
     let now = new Date(),
-      passed = new Date(now - this.updatedDuration),
+      passed = new Date(now - updateDuration),
       prev;
 
     if (err) return cb(err);

--- a/app/database.js
+++ b/app/database.js
@@ -4,7 +4,7 @@ const Datastore = require("nedb");
 
 const DatabaseFactory = function(path){
 
-  this.db = new Datastore({ filename: path, autoload: true });
+  this.db = new Datastore({ filename: path, autoload: true, timestampData: true });
 };
 
 module.exports = DatabaseFactory;

--- a/app/routes/file.js
+++ b/app/routes/file.js
@@ -5,7 +5,7 @@ const fileSystem = require("../helpers/file-system"),
   Header = require("../models/header"),
   url = require("url");
 
-const FileRoute = function(app, proxy, headerDB) {
+const FileRoute = function(app, proxy, headerDB, updateDuration) {
 
   app.get("/files", (req, res, next) => {
     const fileUrl = req.query.url;
@@ -45,7 +45,7 @@ const FileRoute = function(app, proxy, headerDB) {
           getFromCache(res, controller, fileUrl);
 
           // check if file is stale
-          controller.isStale((err, stale) => {
+          controller.isStale(updateDuration, (err, stale) => {
 
             if (err) {
               console.error(err, url);
@@ -59,7 +59,6 @@ const FileRoute = function(app, proxy, headerDB) {
                 //TODO: request file again using request library, not proxy
                 console.log("Request file from server again adding 'If-None-Match' header with etag value", headers.etag);
               });
-
 
             }
 

--- a/app/routes/file.js
+++ b/app/routes/file.js
@@ -43,6 +43,28 @@ const FileRoute = function(app, proxy, headerDB) {
           });
 
           getFromCache(res, controller, fileUrl);
+
+          // check if file is stale
+          controller.isStale((err, stale) => {
+
+            if (err) {
+              console.error(err, url);
+            }
+
+            if (stale) {
+
+              controller.getHeaders((err, headers) => {
+                if (err) { console.error(err, url); }
+
+                //TODO: request file again using request library, not proxy
+                console.log("Request file from server again adding 'If-None-Match' header with etag value", headers.etag);
+              });
+
+
+            }
+
+          });
+
         } else {
           req.on("proxyRes", (proxyRes) => {
             if (proxyRes.statusCode == 200) {

--- a/config/config.js
+++ b/config/config.js
@@ -6,5 +6,6 @@ module.exports = {
   port: 9494,
   url: "localhost",
   downloadPath: path.join(riseCachePath,"download"),
-  headersDBPath: path.join(riseCachePath,"database","headers.db")
+  headersDBPath: path.join(riseCachePath,"database","headers.db"),
+  fileUpdateDuration: 1200000 // 20 minutes
 };

--- a/server.js
+++ b/server.js
@@ -10,6 +10,6 @@ server.init();
 server.start();
 
 require("./app/routes/ping")(server.app, pkg);
-require("./app/routes/file")(server.app, server.proxy, headerDB.db);
+require("./app/routes/file")(server.app, server.proxy, headerDB.db, config.fileUpdateDuration);
 
 server.app.use(error.handleError);

--- a/test/unit/file-test.js
+++ b/test/unit/file-test.js
@@ -266,7 +266,7 @@ describe("FileController", () => {
 
       fileController = new FileController("http://example.com/logo.png", header);
 
-      fileController.isStale( (err, stale) => {
+      fileController.isStale(config.fileUpdateDuration, (err, stale) => {
         expect(stale).to.be.false;
         done();
       });
@@ -286,7 +286,7 @@ describe("FileController", () => {
       // tick clock by 15 minutes
       clock.tick(900000);
 
-      fileController.isStale( (err, stale) => {
+      fileController.isStale(config.fileUpdateDuration, (err, stale) => {
         expect(stale).to.be.true;
         done();
       });

--- a/test/unit/file-test.js
+++ b/test/unit/file-test.js
@@ -195,4 +195,102 @@ describe("FileController", () => {
     });
 
   });
+
+  describe("getTimestampData", () => {
+
+    it("should return an object with timestamp data from DB", (done) => {
+      const newHeader = {data: {key: "test", createdAt: 1472140800000, updatedAt: 1472133000000, headers: {etag: "etag"}}};
+      header = {
+        findByKey: function (key, cb) {
+          cb(null, newHeader);
+        }
+      };
+
+      fileController = new FileController("http://example.com/logo.png", header);
+
+      let headerFindByKeySpy = sinon.spy(header, "findByKey");
+
+      fileController.getTimestampData( (err, timestamp) => {
+        expect(headerFindByKeySpy.calledOnce).to.be.true;
+        expect(timestamp).to.deep.equal({
+          createdAt: newHeader.data.createdAt,
+          updatedAt: newHeader.data.updatedAt
+        });
+        done();
+      });
+    });
+
+    it("should return an error if there is an error on getting timestamp data from DB", (done) => {
+      let errorMessage = "Error getting timestamp data";
+      header = {
+        findByKey: function (key, cb) {
+          cb(new Error(errorMessage));
+        }
+      };
+
+      fileController = new FileController("http://example.com/logo.png", header);
+
+      let headerFindByKeySpy = sinon.spy(header, "findByKey");
+
+      fileController.getTimestampData( (err, timestamp) => {
+        expect(headerFindByKeySpy.calledOnce).to.be.true;
+        expect(timestamp).to.be.undefined;
+        expect(err.message).to.equal(errorMessage);
+        done();
+      });
+    });
+
+  });
+
+  describe("isStale", () => {
+
+    let clock, date;
+
+    before(() => {
+      date = new Date(1472133600000);
+      clock = sinon.useFakeTimers(date.getTime());
+    });
+
+    after(() => {
+      clock.restore();
+    });
+
+    it("should return false when last time checked is less than 20 mins", (done) => {
+      // updatedAt is 10 minutes less than current time
+      const newHeader = {data: {key: "test", createdAt: 1472140800000, updatedAt: 1472133000000, headers: {etag: "etag"}}};
+      header = {
+        findByKey: function (key, cb) {
+          cb(null, newHeader);
+        }
+      };
+
+      fileController = new FileController("http://example.com/logo.png", header);
+
+      fileController.isStale( (err, stale) => {
+        expect(stale).to.be.false;
+        done();
+      });
+    });
+
+    it("should return true when last time checked is more than 20 mins", (done) => {
+      // updatedAt is 10 minutes less than current time
+      const newHeader = {data: {key: "test", createdAt: 1472140800000, updatedAt: 1472133000000, headers: {etag: "etag"}}};
+      header = {
+        findByKey: function (key, cb) {
+          cb(null, newHeader);
+        }
+      };
+
+      fileController = new FileController("http://example.com/logo.png", header);
+
+      // tick clock by 15 minutes
+      clock.tick(900000);
+
+      fileController.isStale( (err, stale) => {
+        expect(stale).to.be.true;
+        done();
+      });
+    });
+
+  });
 });


### PR DESCRIPTION
- Database now includes timestamp data, which will add `createdAt` and `updatedAt` values
- File Controller has `getTimestampData` function for retrieving timestamp data from saved header
- File Controller has `isStale` function for determining if file in cache was last checked over 20 minutes ago
- Unit tests added