### PR TITLE
Handling request for new file version

### DIFF
--- a/app/controllers/file.js
+++ b/app/controllers/file.js
@@ -134,4 +134,23 @@ FileController.prototype.isStale = function(updateDuration, cb) {
   });
 };
 
+FileController.prototype.getUpdateHeaderField = function(cb) {
+  this.getHeaders((err, headers) => {
+    if (err) return cb(err);
+
+    let header = {};
+
+    // prioritize using etag
+    if (headers.hasOwnProperty("etag") && headers.etag !== "") {
+      header["If-None-Match"] = headers.etag;
+    }
+    else if (headers.hasOwnProperty("last-modified")) {
+      header["If-Modified-Since"] = headers["last-modified"];
+    }
+
+    return cb(null, header);
+
+  });
+};
+
 module.exports = FileController;

--- a/app/controllers/file.js
+++ b/app/controllers/file.js
@@ -20,12 +20,27 @@ const FileController = function(url, header) {
 util.inherits(FileController, EventEmitter);
 
 /* Download file and save to disk. */
-FileController.prototype.downloadFile = function() {
+FileController.prototype.downloadFile = function(opts) {
+  let options = {};
+
   if (this.url) {
-    request.get(this.url)
+
+    options.url = this.url;
+    options.headers = {
+      "User-Agent": "request"
+    };
+
+    if (opts) {
+      Object.assign(options.headers, opts);
+    }
+
+    request.get(options)
       .on("response", (res) => {
         if (res.statusCode == 200) {
           this.writeFile(res);
+        }
+        else if (res.statusCode == 304) {
+          this.saveHeaders(res.headers);
         }
       })
       .on("error", (err) => {

--- a/app/helpers/file-system.js
+++ b/app/helpers/file-system.js
@@ -26,7 +26,7 @@ module.exports = {
   },
 
   move: function(from, to, cb) {
-    fs.move(from, to, cb);
+    fs.move(from, to, {clobber: true}, cb);
   },
 
   getFileName: function(url) {

--- a/app/routes/file.js
+++ b/app/routes/file.js
@@ -43,11 +43,31 @@ const FileRoute = function(app, headerDB, updateDuration) {
 
             if (stale) {
 
-              controller.getUpdateHeaderField((err, field) => {
-                if (err) { console.error(err, fileUrl); }
+              // Check if the file is downloading.
+              fileSystem.isDownloading(fileUrl, (downloading) => {
+                if (!downloading) {
 
-                //TODO: request file again using request library, not proxy
-                console.log("Request file from server again with header field", field);
+                  // get the appropriate header field for request
+                  controller.getUpdateHeaderField((err, field) => {
+                    if (err) { console.error(err, fileUrl); }
+
+                    controller.on("downloaded", () => {
+                      console.info("Latest File Downloaded", fileUrl, new Date());
+                    });
+
+                    controller.on("request-error", (err) => {
+                      console.error(err, fileUrl, new Date());
+                    });
+
+                    controller.on("move-file-error", (err) => {
+                      console.error(err, fileUrl, new Date());
+                    });
+
+                    // Make request to download file passing request header
+                    controller.downloadFile(field);
+                  });
+
+                }
               });
             }
           });

--- a/app/routes/file.js
+++ b/app/routes/file.js
@@ -43,11 +43,11 @@ const FileRoute = function(app, headerDB, updateDuration) {
 
             if (stale) {
 
-              controller.getHeaders((err, headers) => {
+              controller.getUpdateHeaderField((err, field) => {
                 if (err) { console.error(err, fileUrl); }
 
                 //TODO: request file again using request library, not proxy
-                console.log("Request file from server again adding 'If-None-Match' header with etag value", headers.etag);
+                console.log("Request file from server again with header field", field);
               });
             }
           });

--- a/test/unit/file-test.js
+++ b/test/unit/file-test.js
@@ -445,4 +445,60 @@ describe("FileController", () => {
 
   });
 
+  describe("getUpdateHeaderField", () => {
+
+    it("should return 'If-None-Match' field when etag exists", (done) => {
+      const newHeader = {data: {key: "test", headers: {etag: "etag", "last-modified": "Thu, 25 Aug 2016 14:53:30 GMT"}}};
+      header = {
+        findByKey: function (key, cb) {
+          cb(null, newHeader);
+        }
+      };
+
+      fileController = new FileController("http://example.com/logo.png", header);
+
+      fileController.getUpdateHeaderField( (err, field) => {
+        expect(field).to.deep.equal({
+          "If-None-Match": newHeader.data.headers.etag
+        });
+        done();
+      });
+    });
+
+    it("should return 'If-Modified-Since' field when etag not present and use last-modified", (done) => {
+      const newHeader = {data: {key: "test", headers: {"last-modified": "Thu, 25 Aug 2016 14:53:30 GMT"}}};
+      header = {
+        findByKey: function (key, cb) {
+          cb(null, newHeader);
+        }
+      };
+
+      fileController = new FileController("http://example.com/logo.png", header);
+
+      fileController.getUpdateHeaderField( (err, field) => {
+        expect(field).to.deep.equal({
+          "If-Modified-Since": newHeader.data.headers["last-modified"]
+        });
+        done();
+      });
+    });
+
+    it("should return an error if there is an error on getting headers from DB", (done) => {
+      let errorMessage = "Error getting timestamp data";
+      header = {
+        findByKey: function (key, cb) {
+          cb(new Error(errorMessage));
+        }
+      };
+
+      fileController = new FileController("http://example.com/logo.png", header);
+
+      fileController.getUpdateHeaderField( (err, field) => {
+        expect(field).to.be.undefined;
+        expect(err.message).to.equal(errorMessage);
+        done();
+      });
+    });
+
+  });
 });

--- a/test/unit/file-test.js
+++ b/test/unit/file-test.js
@@ -81,6 +81,31 @@ describe("FileController", () => {
       });
     });
 
+    it("should save headers when response is 304", (done) => {
+      let header = {
+        save: function (cb) {
+          cb(null, {});
+        },
+        set: function () {
+
+        }
+      };
+
+      fileController = new FileController("http://abc123.com/logo.png", header);
+
+      nock("http://abc123.com")
+        .get("/logo.png")
+        .replyWithFile(304, "/data/logo.png");
+
+      fileController.downloadFile();
+
+      fileController.on("headers", () => {
+        expect(true).to.be.true;
+        done();
+      });
+
+    });
+
     it("should emit 'request-error' event if file server responds with an error", (done) => {
       fileController.downloadFile();
 


### PR DESCRIPTION
- When file is stale, checks to see if file is already downloading, if not, it gets appropriate header field for including in the request for the file
- `downloadFile` revised to use optional headers in request and checks for a 304 response and saves headers if so
- ensuring the move of the file from download to cache overwrites the old one
- unit tests added
