### PR TITLE
Appending display id to storage file requests

### DIFF
--- a/app/controllers/file.js
+++ b/app/controllers/file.js
@@ -23,11 +23,20 @@ util.inherits(FileController, EventEmitter);
 
 /* Download file and save to disk. */
 FileController.prototype.downloadFile = function(opts) {
-  let options = {};
+  let options = {},
+    displayId = this.riseDisplayNetworkII.get("displayid");
 
   if (this.url) {
 
     options.url = this.url;
+
+    if (displayId) {
+      if (this.isStorageFile(options.url)) {
+        // append the display id to the request url so that it is included in our storage logs for throttled analysis
+        options.url = this.getUrlWithDisplayID(options.url, displayId);
+      }
+    }
+
     options.headers = {
       "User-Agent": "request"
     };
@@ -173,6 +182,15 @@ FileController.prototype.getUpdateHeaderField = function(cb) {
     return cb(null, header);
 
   });
+};
+
+FileController.prototype.isStorageFile = function(url) {
+  return decodeURIComponent(url).indexOf("storage.googleapis.com") > -1 ||
+    decodeURIComponent(url).indexOf("googleapis.com/storage") > -1;
+};
+
+FileController.prototype.getUrlWithDisplayID = function (url, displayId) {
+  return url + (url.indexOf("?") > -1 ? (url.slice(-1) == "&" ? "":"&") : "?" ) + "displayid=" + displayId;
 };
 
 module.exports = FileController;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-cache-v2",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Rise Cache for Rise Player",
   "main": "rise-cache.js",
   "scripts": {

--- a/test/unit/file-test.js
+++ b/test/unit/file-test.js
@@ -534,4 +534,38 @@ describe("FileController", () => {
     });
 
   });
+
+  describe("isStorageFile", () => {
+
+    it("should return true for url containing 'storage.googleapis.com'", () => {
+      let url = "https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%2Ftest.jpg";
+      expect(fileController.isStorageFile(url)).to.be.true;
+    });
+
+    it("should return true for url containing 'googleapis.com/storage'", () => {
+      let url = "https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%2Ftest.jpg?alt=media";
+      expect(fileController.isStorageFile(url)).to.be.true;
+    });
+
+    it("should return false for non-storage url", () => {
+      let url = "http://test.com/images/test.jpg";
+      expect(fileController.isStorageFile()).to.be.false;
+    });
+
+  });
+
+  describe("getUrlWithDisplayID", () => {
+
+    it("should return url with display id as query param", () => {
+      let url = "https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%2Ftest.jpg";
+      expect(fileController.getUrlWithDisplayID(url, "ABC123")).to.equal(url + "?displayid=ABC123");
+    });
+
+    it("should return url with display id as additional query param", () => {
+      let url = "https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%2Ftest.jpg?alt=media";
+      expect(fileController.getUrlWithDisplayID(url, "ABC123")).to.equal(url + "&displayid=ABC123");
+    });
+
+
+  });
 });


### PR DESCRIPTION
- Obtain display id from RiseDisplayNetworkII file
- Check to see if file url is of a rise storage nature
- If file is a storage file, append the display id to the url for the request
- Unit tests added