### PR TITLE
Gracefully handling potential startup errors

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -18,14 +18,26 @@ const AppFactory = function() {
     fileSystem.createDir(config.downloadPath);
     fileSystem.createDir(config.cachePath);
 
-    const riseDisplayNetworkII = PropertiesReader(config.riseDisplayNetworkIIPath);
+    const riseDisplayNetworkII = fileSystem.fileExists(config.riseDisplayNetworkIIPath, (exists) => {
+      if (exists) {
+        return PropertiesReader(config.riseDisplayNetworkIIPath);
+      } else {
+        console.warn("RiseDisplayNetworkIIPath.ini file not found.");
+        return null;
+      }
+    });
     const headerDB = new Database(config.headersDBPath);
     const metadataDB = new Database(config.metadataDBPath);
     const cleanupJob = new CleanupJob(config, headerDB.db, metadataDB.db);
 
     server.app.use(cors());
 
-    cleanupJob.run();
+    fileSystem.fileExists(config.cachePath, (exists) => {
+      if (exists) {
+        cleanupJob.run();
+      }
+    });
+
     server.start();
 
     require("./routes/ping")(server.app, pkg);

--- a/app/controllers/file.js
+++ b/app/controllers/file.js
@@ -24,7 +24,7 @@ util.inherits(FileController, EventEmitter);
 /* Download file and save to disk. */
 FileController.prototype.downloadFile = function(opts) {
   let options = {},
-    displayId = this.riseDisplayNetworkII.get("displayid");
+    displayId = (this.riseDisplayNetworkII) ? this.riseDisplayNetworkII.get("displayid") : null;
 
   if (this.url) {
 
@@ -41,7 +41,7 @@ FileController.prototype.downloadFile = function(opts) {
       "User-Agent": "request"
     };
 
-    options.proxy = this.riseDisplayNetworkII.get("proxy");
+    options.proxy = (this.riseDisplayNetworkII) ? this.riseDisplayNetworkII.get("proxy"): null;
 
     if (opts) {
       Object.assign(options.headers, opts);

--- a/app/controllers/metadata.js
+++ b/app/controllers/metadata.js
@@ -19,7 +19,13 @@ util.inherits(MetadataController, EventEmitter);
 /* Get folder/file metadata and store it on db. */
 MetadataController.prototype.getMetadata = function() {
   if (this.url) {
-    const requestOptions = { method: "GET", url: this.url, json: true, proxy: this.riseDisplayNetworkII.get("proxy") };
+    const requestOptions = {
+      method: "GET",
+      url: this.url,
+      json: true,
+      proxy: (this.riseDisplayNetworkII) ? this.riseDisplayNetworkII.get("proxy"): null
+    };
+
     request(requestOptions, (err, res, body) => {
       if (err) console.error(err, this.url);
 

--- a/test/unit/file-test.js
+++ b/test/unit/file-test.js
@@ -76,6 +76,26 @@ describe("FileController", () => {
       });
     });
 
+    it("should save downloaded file without RiseDisplayNetworkII.ini file", (done) => {
+      let controller = new FileController("http://abc123.com/logo.png", header, null);
+
+      nock("http://abc123.com")
+        .get("/logo.png")
+        .replyWithFile(200, "/data/logo.png");
+
+      controller.downloadFile();
+
+      controller.on("downloaded", () => {
+        const stats = fs.stat(config.downloadPath + "/0e36e4d268b63fd0573185fe3a9e01f0", (err, stats) => {
+          expect(err).to.be.null;
+          expect(stats).to.not.be.null;
+          expect(stats.isFile()).to.be.true;
+
+          done();
+        });
+      });
+    });
+
     it("should emit 'downloaded' event", (done) => {
       nock("http://abc123.com")
         .get("/logo.png")

--- a/test/unit/metadata-ctrl-test.js
+++ b/test/unit/metadata-ctrl-test.js
@@ -53,6 +53,21 @@ describe("MetadataController", () => {
       });
     });
 
+    it("should get metadata without RiseDisplayNetworkII.ini file", (done) => {
+      var controller = new MetadataController("https://storage-dot-rvaserver2.appspot.com/_ah/api/storage/v0.01/files?companyId=30007b45-3df0-4c7b-9f7f-7d8ce6443013%26folder=Images%2Fsdsu%2F", metadata, null);
+
+      nock("https://storage-dot-rvaserver2.appspot.com")
+        .get("/_ah/api/storage/v0.01/files?companyId=30007b45-3df0-4c7b-9f7f-7d8ce6443013%26folder=Images%2Fsdsu%2F")
+        .reply(200, metadataResponse);
+
+      controller.getMetadata();
+
+      controller.on("response", (data) => {
+        expect(data).to.deep.equal(metadataResponse);
+        done();
+      });
+    });
+
     it("should emit 'response' event", (done) => {
       nock("https://storage-dot-rvaserver2.appspot.com")
         .get("/_ah/api/storage/v0.01/files?companyId=30007b45-3df0-4c7b-9f7f-7d8ce6443013%26folder=Images%2Fsdsu%2F")
@@ -156,7 +171,7 @@ describe("MetadataController", () => {
 
   });
 
-  describe("getMetadata", () => {
+  describe("getCachedMetadata", () => {
 
     it("should get the metadata from DB", (done) => {
       const newMetadata = {data: {key: "test", metadata: {etag: "etag"}}};


### PR DESCRIPTION
- Check if RiseDisplayNetworkII.ini file exists and if it doesn't then store as `null` value and warn in the console
- Check if the cache directory exists and if so run the cleanup job