### PR TITLE
Logging error when no headers are available for cached file

### DIFF
--- a/app/helpers/file-system.js
+++ b/app/helpers/file-system.js
@@ -105,13 +105,17 @@ module.exports = {
 
   cleanupLogFile: function() {
     fs.truncate(config.logFilePath, 0, (err) => {
-      if (err) console.error(err);
+      if (err && config.debugging) {
+        console.error(err);
+      }
     });
   },
 
   appendToLog: function(datetime, message) {
     fs.appendFile(config.logFilePath, datetime + " - " + message + "\n", (err) => {
-      if (err) console.error(err);
+      if (err && config.debugging) {
+        console.error(err);
+      }
     });
   }
 

--- a/app/routes/file.js
+++ b/app/routes/file.js
@@ -25,7 +25,12 @@ const FileRoute = function(app, headerDB, riseDisplayNetworkII, config, logger) 
           controller.getHeaders((err, headers) => {
 
             if (err) {
-              console.error(err, fileUrl);
+              logger.error(err, fileUrl);
+            }
+            else {
+              if (!headers) {
+                logger.error("No headers available", fileUrl);
+              }
             }
             res.setHeader("Access-Control-Allow-Origin", "*");
             res.setHeader("Cache-Control", "no-cache");
@@ -35,7 +40,7 @@ const FileRoute = function(app, headerDB, riseDisplayNetworkII, config, logger) 
           });
 
           // check if file is stale
-          controller.isStale(config.updateDuration, (err, stale) => {
+          controller.isStale(config.fileUpdateDuration, (err, stale) => {
 
             if (err) {
               console.error(err, fileUrl);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-cache-v2",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Rise Cache for Rise Player",
   "main": "rise-cache.js",
   "scripts": {

--- a/test/integration/file-test.js
+++ b/test/integration/file-test.js
@@ -501,6 +501,28 @@ describe("/files endpoint", () => {
         });
     });
 
+    it("should log an error when headers are not available", (done) => {
+      let spy = sinon.spy(logger, "error");
+
+      mock({
+        [config.cachePath]: {
+          "cdf42c077fe6037681ae3c003550c2c5": "some content"
+        },
+        [config.headersDBPath]: ""
+      });
+
+      headerDB.db.loadDatabase();
+
+      chai.request("http://localhost:9494")
+        .get("/files")
+        .query({ url: "http://example.com/logo.png" })
+        .end(() => {
+          expect(spy.calledWith("No headers available", "http://example.com/logo.png"));
+          logger.error.restore();
+          done();
+        });
+    });
+
     it("should return an error if file exists but could not be read", (done) => {
       // Create file with no read permissions.
       mock({


### PR DESCRIPTION
- Logging error when `controller.getHeaders()` returns an error
- Logging error when `controller.getHeaders()` provides no headers
- Correcting name of `config.fileUpdateDuration`
- Ensuring helper functions regarding log file only report error in console when in debugging
- Added integration test
- Bumped version