### PR TITLE
Adding "displays" endpoint for obtaining display id

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -53,6 +53,7 @@ const AppFactory = function() {
       server.start();
 
       require("./routes/ping")(server.app, pkg);
+      require("./routes/display")(server.app, displayId);
       require("./routes/file")(server.app, headerDB.db, riseDisplayNetworkII, config, logger);
       require("./routes/metadata")(server.app, metadataDB.db, riseDisplayNetworkII);
 

--- a/app/routes/display.js
+++ b/app/routes/display.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const DisplayRoute = function(app, displayId) {
+
+  app.get("/displays", (req, res) => {
+    const response = { displayId : displayId };
+
+    res.json(response);
+  });
+
+};
+
+module.exports = DisplayRoute;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-cache-v2",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Rise Cache for Rise Player",
   "main": "rise-cache.js",
   "scripts": {

--- a/test/integration/display-test.js
+++ b/test/integration/display-test.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const chai = require("chai"),
+  chaiHttp = require("chai-http"),
+  config = require("../../config/config"),
+  error = require("../../app/middleware/error"),
+  expect = chai.expect;
+
+chai.use(chaiHttp);
+
+describe("/displays endpoint", () => {
+  let logger = {
+    info: function (x){},
+    error:function (x){},
+    warn: function (x){}
+  };
+  let server = require("../../app/server")(config, logger);
+
+  let riseDisplayNetworkII = {
+    get: function (property) {
+      if (property == "activeproxy") {
+        return "";
+      }
+
+      if (property == "displayid") {
+        return "abc123";
+      }
+    }
+  };
+
+  before(() => {
+    require("../../app/routes/display")(server.app, riseDisplayNetworkII.get("displayid"));
+  });
+
+  beforeEach(() => {
+    server.start();
+    server.app.use(error.handleError);
+  });
+
+  afterEach(() => {
+    server.stop();
+  });
+
+  it("should return displayId", function (done) {
+    chai.request('http://localhost:9494')
+      .get('/displays')
+      .end(function(err, res) {
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res.body).to.be.a('object');
+        expect(res.body.displayId).to.be.equal("abc123");
+        done();
+      });
+  });
+});


### PR DESCRIPTION
- New route endpoint "displays" added which returns a JSON response with `displayId` value
- Integration test added
- Feature version bump