### PR TITLE
Added the delete method for spreadsheets endpoint

### DIFF
--- a/app/controllers/data.js
+++ b/app/controllers/data.js
@@ -40,5 +40,15 @@ DataController.prototype.getData = function(key) {
   });
 };
 
+DataController.prototype.deleteData = function(key) {
+  this.model.delete(key, (err, numRemoved) => {
+    if (err) {
+      return this.emit("delete-data-error", err);
+    }
+
+    this.emit("delete-data", numRemoved);
+
+  });
+};
 
 module.exports = DataController;

--- a/app/models/data.js
+++ b/app/models/data.js
@@ -28,4 +28,11 @@ Data.prototype.findByKey = function (key, callback) {
   });
 };
 
+Data.prototype.delete = function (key, callback) {
+  this.db.remove({ key: key }, {}, (err, numRemoved) => {
+    if (err) return callback(err);
+    callback(null, numRemoved);
+  });
+};
+
 module.exports = Data;

--- a/app/routes/spreadsheets.js
+++ b/app/routes/spreadsheets.js
@@ -55,6 +55,28 @@ const SpreadsheetsRoute = function(app, db, logger) {
     controller.getData(key);
   });
 
+  app.delete("/spreadsheets/:key", (req, res, next) => {
+    let key = req.params.key;
+
+    controller.on("delete-data", (numRemoved) => {
+      if (numRemoved > 0) {
+        res.status(204).json();
+      } else {
+        res.statusCode = 404;
+        next(new Error("Not found"));
+      }
+
+    });
+
+    controller.on("delete-data-error", (err) => {
+      logger.error("Could not delete spreadsheet data", key);
+      res.statusCode = 500;
+      next(err);
+    });
+
+    controller.deleteData(key);
+  });
+
 };
 
 module.exports = SpreadsheetsRoute;

--- a/test/integration/spreadsheets-test.js
+++ b/test/integration/spreadsheets-test.js
@@ -106,4 +106,27 @@ describe("/spreadsheets endpoint", () => {
         done();
       });
   });
+
+  it("should delete data", function (done) {
+
+    chai.request("http://localhost:9494")
+      .delete("/spreadsheets/" + spreadsheetData.key)
+      .end((err, res) => {
+        expect(res).to.have.status(204);
+
+        done();
+      });
+  });
+
+  it("should return 404 if data to delete was not found", function (done) {
+
+    chai.request("http://localhost:9494")
+      .get("/spreadsheets/" + spreadsheetData.key)
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body).to.deep.equal({ status: 404, message: "Not found" });
+
+        done();
+      });
+  });
 });

--- a/test/unit/data-test.js
+++ b/test/unit/data-test.js
@@ -16,6 +16,9 @@ describe("DataController", () => {
         cb(null,{
           data: spreadsheetData
         });
+      },
+      delete: function(key, cb) {
+        cb(null, 1);
       }
     };
 
@@ -77,6 +80,46 @@ describe("DataController", () => {
       controller.getData(spreadsheetData.key);
     });
 
+  });
+
+  describe("deleteData", () => {
+    it("should emit 'delete-data' event if data was deleted", (done) => {
+      controller.on("delete-data", (numRemoved) => {
+        expect(numRemoved).to.equal(1);
+
+        done();
+      });
+
+      controller.deleteData(spreadsheetData.key);
+    });
+
+    it("should emit 'delete-data' event if no data was deleted", (done) => {
+      model.delete = function (key, cb) {
+        cb(null, 0);
+      };
+
+      controller.on("delete-data", (numRemoved) => {
+        expect(numRemoved).to.equal(0);
+
+        done();
+      });
+
+      controller.deleteData(spreadsheetData.key);
+    });
+
+    it("should emit 'delete-data-error' event if problem deleting the data", (done) => {
+      model.delete = function (key, cb) {
+        cb(new Error("err"));
+      };
+
+      controller.on("delete-data-error", (err) => {
+        expect(err.message).to.equal("err");
+
+        done();
+      });
+
+      controller.deleteData(spreadsheetData.key);
+    });
   });
 
 });


### PR DESCRIPTION
- Returning a `204` response when successfully deleted
- Returning a `404` when the there was no data removed
- Logging error and responding with `500` when there was a problem deleting
- Unit and integration tests added