### PR TITLE
fixed the error where headers are already sent

### DIFF
--- a/app/controllers/file.js
+++ b/app/controllers/file.js
@@ -53,6 +53,7 @@ FileController.prototype.downloadFile = function(opts) {
 
     request.get(options)
       .on("response", (res) => {
+        this.hasDownloadError = false;
         if (res.statusCode == 200) {
           this.writeFile(res);
           this.emit("downloading");

--- a/app/controllers/file.js
+++ b/app/controllers/file.js
@@ -18,6 +18,7 @@ const FileController = function(url, header, riseDisplayNetworkII) {
   this.pathInCache = fileSystem.getPathInCache(this.url);
   this.pathInDownload = fileSystem.getPathInDownload(this.url);
   this.riseDisplayNetworkII = riseDisplayNetworkII;
+  this.hasDownloadError = false;
 };
 
 util.inherits(FileController, EventEmitter);
@@ -63,6 +64,7 @@ FileController.prototype.downloadFile = function(opts) {
         }
       })
       .on("error", (err) => {
+        this.hasDownloadError = true;
         this.deleteFileFromDownload();
         this.emit("request-error", err);
       });
@@ -106,9 +108,11 @@ FileController.prototype.writeFile = function(res) {
 
   file.on("finish", () => {
     file.close(() => {
-      this.saveHeaders(res.headers);
-      this.moveFileFromDownloadToCache();
-      this.emit("downloaded");
+      if (!this.hasDownloadError) {
+        this.saveHeaders(res.headers);
+        this.moveFileFromDownloadToCache();
+        this.emit("downloaded");
+      }
     });
   }).on("error", (err) => {
     fs.unlink(this.pathInDownload);

--- a/app/routes/file.js
+++ b/app/routes/file.js
@@ -149,11 +149,13 @@ const FileRoute = function(app, headerDB, riseDisplayNetworkII, config, logger) 
   }
 
   function sendResponse(res, statusCode, message, fileUrl) {
-    res.status(statusCode)
-      .send({
-        status: statusCode,
-        message: message
-      });
+    if (!res.headersSent) {
+      res.status(statusCode)
+        .send({
+          status: statusCode,
+          message: message
+        });
+    }
   }
 };
 


### PR DESCRIPTION
@donnapep @stulees I have fixed the issue where it complains that the headers were already sent. I also have put a check to not emit a downloaded event if the download of the file has failed. Unfortunately, for both I did not find a way to add tests. I think it is possible but we need to mock the response.pipe function. Looking at the mock library we are using for it https://github.com/howardabrams/node-mocks-http it does not support pipe. So I think we can come back to this once we find a way to do it.

Please review. cheers  