### PR TITLE
Fix/wrong os logging

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -5,6 +5,13 @@ const rvplayerPath = (process.platform === "win32") ?
   path.join(os.homedir(), "rvplayer");
 const riseCachePath = path.join(rvplayerPath, "RiseCache");
 
+const getOS = function () {
+  if (process.platform === "win32") {
+    return (process.arch === "x64" || process.env.hasOwnProperty("PROCESSOR_ARCHITEW6432")) ? "win64" : process.platform
+  } else {
+    return process.platform;
+  }
+}
 module.exports = {
   port: 9494,
   url: "localhost",
@@ -19,7 +26,7 @@ module.exports = {
   fileUpdateDuration: 1200000, // 20 minutes,
   requestTimeout: 120000, // 2 minutes
   debugging: process.argv.slice(1).join(" ").indexOf("debug") > -1,
-  os: process.platform,
+  os: getOS(),
   bqProjectName: "client-side-events",
   bqDataset: "Rise_Cache_V2"
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-cache-v2",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Rise Cache for Rise Player",
   "main": "rise-cache.js",
   "scripts": {


### PR DESCRIPTION
There is a known issue where process.platform will return win32 even though it is running on a 64bit windows. That happens because it is a 32 bit node installed on a 64bit windows. Added some other checks to get the system architecture. 

@donnapep @stulees please review. cheers 