### PR TITLE
Logger improvements

### DIFF
--- a/app/controllers/metadata.js
+++ b/app/controllers/metadata.js
@@ -29,7 +29,7 @@ MetadataController.prototype.getMetadata = function() {
 
     request(requestOptions, (err, res, body) => {
       if (err) {
-        this.logger.error(err, this.url);
+        this.logger.error(err, null, this.url);
       }
 
       if (err || res.statusCode != 200) {

--- a/app/helpers/logger/external-logger-bigquery.js
+++ b/app/helpers/logger/external-logger-bigquery.js
@@ -15,7 +15,7 @@ const ExternalLoggerBigQuery = function (bqClient, displayId, cacheVersion, os, 
     return "" + year + month + day;
   };
 
-  const log = function (eventName, eventDetails, errorDetails, nowDate, logDatetime) {
+  const log = function (eventName, eventDetails, fileUrl, fileName, errorDetails, nowDate, logDatetime) {
     if (!eventName) {return Promise.reject("eventName is required");}
     if (!nowDate || !Date.prototype.isPrototypeOf(nowDate)) {
       nowDate = new Date();
@@ -28,7 +28,9 @@ const ExternalLoggerBigQuery = function (bqClient, displayId, cacheVersion, os, 
       display_id: displayId || "no-displayId",
       cache_version: cacheVersion || "no-risecache",
       os: os,
-      ts: nowDate.toISOString()
+      ts: nowDate.toISOString(),
+      file_name: fileName || fileSystem.getFileName(fileUrl),
+      file_url: fileUrl || ""
     };
 
     return bqClient.insert("events", data, nowDate, getDateForTableName(nowDate))

--- a/app/helpers/logger/external-logger-bigquery.js
+++ b/app/helpers/logger/external-logger-bigquery.js
@@ -15,7 +15,7 @@ const ExternalLoggerBigQuery = function (bqClient, displayId, cacheVersion, os, 
     return "" + year + month + day;
   };
 
-  const log = function (eventName, eventDetails, fileUrl, fileName, errorDetails, nowDate, logDatetime) {
+  const log = function (eventName, eventDetails, fileUrl = "", fileName = fileSystem.getFileName(fileUrl), errorDetails, nowDate, logDatetime) {
     if (!eventName) {return Promise.reject("eventName is required");}
     if (!nowDate || !Date.prototype.isPrototypeOf(nowDate)) {
       nowDate = new Date();
@@ -29,8 +29,8 @@ const ExternalLoggerBigQuery = function (bqClient, displayId, cacheVersion, os, 
       cache_version: cacheVersion || "no-risecache",
       os: os,
       ts: nowDate.toISOString(),
-      file_name: fileName || fileSystem.getFileName(fileUrl),
-      file_url: fileUrl || ""
+      file_name: fileName,
+      file_url: fileUrl
     };
 
     return bqClient.insert("events", data, nowDate, getDateForTableName(nowDate))

--- a/app/helpers/logger/logger.js
+++ b/app/helpers/logger/logger.js
@@ -18,31 +18,35 @@ const Logger = function (debugging, externalLogger, fileSystem) {
 
   };
 
-  const error = function (detail, errorDetail) {
+  const getMessage = function (type, detail, fileUrl) {
+    return type + ": " + detail + ((fileUrl) ? " - " + fileUrl : "");
+  };
+
+  const error = function (detail, errorDetail, fileUrl, fileName) {
     let logDatetime = getLogDatetime();
-    let message = "ERROR: " + detail + " " + errorDetail;
+    let message = getMessage("ERROR", detail + " " + errorDetail, fileUrl);
     if (debugging) console.error(logDatetime + " - " + message);
 
     fileSystem.appendToLog(logDatetime, message);
-    if (externalLogger) {externalLogger.log("error", detail, errorDetail, null, logDatetime);}
+    if (externalLogger) {externalLogger.log("error", detail, fileUrl, fileName, errorDetail, null, logDatetime);}
   };
 
-  const info = function (detail) {
+  const info = function (detail, fileUrl, fileName) {
     let logDatetime = getLogDatetime();
-    let message = "INFO: " + detail;
+    let message = getMessage("INFO", detail, fileUrl);
     if (debugging) console.info(logDatetime + " - " + message);
 
     fileSystem.appendToLog(logDatetime, message);
-    if (externalLogger) {externalLogger.log("info", detail, null, logDatetime);}
+    if (externalLogger) {externalLogger.log("info", detail, fileUrl, fileName, null, logDatetime);}
   };
 
-  const warn = function (detail) {
+  const warn = function (detail, fileUrl, fileName) {
     let logDatetime = getLogDatetime();
-    let message = "WARNING: " + detail;
+    let message = getMessage("WARNING", detail, fileUrl);
     if (debugging) console.warn(logDatetime + " - " + message);
 
     fileSystem.appendToLog(logDatetime, message);
-    if (externalLogger) {externalLogger.log("warning", detail, null, logDatetime);}
+    if (externalLogger) {externalLogger.log("warning", detail, fileUrl, fileName, null, logDatetime);}
   };
 
   return {

--- a/app/helpers/logger/logger.js
+++ b/app/helpers/logger/logger.js
@@ -19,13 +19,14 @@ const Logger = function (debugging, externalLogger, fileSystem) {
   };
 
   const getMessage = function (type, detail, fileUrl) {
-    return type + ": " + detail + ((fileUrl) ? " - " + fileUrl : "");
+    let file = (fileUrl) ? `- ${fileUrl}` : "";
+    return `${type}: ${detail}${file}`;
   };
 
   const error = function (detail, errorDetail, fileUrl, fileName) {
     let logDatetime = getLogDatetime();
-    let message = getMessage("ERROR", detail + " " + errorDetail, fileUrl);
-    if (debugging) console.error(logDatetime + " - " + message);
+    let message = getMessage("ERROR", `${detail} ${errorDetail}`, fileUrl);
+    if (debugging) console.error(`${logDatetime} - ${message}`);
 
     fileSystem.appendToLog(logDatetime, message);
     if (externalLogger) {externalLogger.log("error", detail, fileUrl, fileName, errorDetail, null, logDatetime);}
@@ -34,7 +35,7 @@ const Logger = function (debugging, externalLogger, fileSystem) {
   const info = function (detail, fileUrl, fileName) {
     let logDatetime = getLogDatetime();
     let message = getMessage("INFO", detail, fileUrl);
-    if (debugging) console.info(logDatetime + " - " + message);
+    if (debugging) console.info(`${logDatetime} - ${message}`);
 
     fileSystem.appendToLog(logDatetime, message);
     if (externalLogger) {externalLogger.log("info", detail, fileUrl, fileName, null, logDatetime);}
@@ -43,7 +44,7 @@ const Logger = function (debugging, externalLogger, fileSystem) {
   const warn = function (detail, fileUrl, fileName) {
     let logDatetime = getLogDatetime();
     let message = getMessage("WARNING", detail, fileUrl);
-    if (debugging) console.warn(logDatetime + " - " + message);
+    if (debugging) console.warn(`${logDatetime} - ${message}`);
 
     fileSystem.appendToLog(logDatetime, message);
     if (externalLogger) {externalLogger.log("warning", detail, fileUrl, fileName, null, logDatetime);}

--- a/app/helpers/logger/logger.js
+++ b/app/helpers/logger/logger.js
@@ -18,14 +18,13 @@ const Logger = function (debugging, externalLogger, fileSystem) {
 
   };
 
-  const getMessage = function (type, detail, fileUrl) {
-    let file = (fileUrl) ? `- ${fileUrl}` : "";
-    return `${type}: ${detail}${file}`;
+  const getMessage = function (type, detail, fileUrl = "", fileName = fileSystem.getFileName(fileUrl)) {
+    return (fileUrl) ? `${type}: ${detail} ${fileUrl} ${fileName}` : `${type}: ${detail}`;
   };
 
   const error = function (detail, errorDetail, fileUrl, fileName) {
     let logDatetime = getLogDatetime();
-    let message = getMessage("ERROR", `${detail} ${errorDetail}`, fileUrl);
+    let message = getMessage("ERROR", `${detail} ${errorDetail}`, fileUrl, fileName);
     if (debugging) console.error(`${logDatetime} - ${message}`);
 
     fileSystem.appendToLog(logDatetime, message);
@@ -34,7 +33,7 @@ const Logger = function (debugging, externalLogger, fileSystem) {
 
   const info = function (detail, fileUrl, fileName) {
     let logDatetime = getLogDatetime();
-    let message = getMessage("INFO", detail, fileUrl);
+    let message = getMessage("INFO", detail, fileUrl, fileName);
     if (debugging) console.info(`${logDatetime} - ${message}`);
 
     fileSystem.appendToLog(logDatetime, message);
@@ -43,7 +42,7 @@ const Logger = function (debugging, externalLogger, fileSystem) {
 
   const warn = function (detail, fileUrl, fileName) {
     let logDatetime = getLogDatetime();
-    let message = getMessage("WARNING", detail, fileUrl);
+    let message = getMessage("WARNING", detail, fileUrl, fileName);
     if (debugging) console.warn(`${logDatetime} - ${message}`);
 
     fileSystem.appendToLog(logDatetime, message);

--- a/app/jobs/cleanup.js
+++ b/app/jobs/cleanup.js
@@ -32,9 +32,9 @@ CleanupJob.prototype.run = function() {
 
             fileSystem.delete(filePath, (err) => {
               if (err) {
-                this.logger.error(err, filePath);
+                this.logger.error(err, null, filePath, file);
               } else {
-                this.logger.info("File deleted");
+                this.logger.info("File deleted", filePath, file);
               }
             });
 
@@ -42,9 +42,9 @@ CleanupJob.prototype.run = function() {
             this.header.set("key", file);
             this.header.delete(file, (err, numRemoved) => {
               if (err) {
-                this.logger.error(err, filePath);
+                this.logger.error(err, null, filePath, file);
               } else if (numRemoved > 0) {
-                this.logger.info("File headers deleted");
+                this.logger.info("File headers deleted", filePath, file);
               }
             });
 
@@ -52,9 +52,9 @@ CleanupJob.prototype.run = function() {
             this.metadata.set("key", file);
             this.metadata.delete(file, (err, numRemoved) => {
               if (err) {
-                this.logger.error(err, filePath);
+                this.logger.error(err, null, filePath, file);
               } else if (numRemoved > 0) {
-                this.logger.info("File metadata deleted");
+                this.logger.info("File metadata deleted", filePath, file);
               }
 
               fileCount++;

--- a/app/routes/file.js
+++ b/app/routes/file.js
@@ -25,11 +25,11 @@ const FileRoute = function(app, headerDB, riseDisplayNetworkII, config, logger) 
           controller.getHeaders((err, headers) => {
 
             if (err) {
-              logger.error(err, fileUrl);
+              logger.error(err, null, fileUrl);
             }
             else {
               if (!headers) {
-                logger.error("No headers available", fileUrl);
+                logger.error("No headers available", null, fileUrl);
               }
             }
             res.setHeader("Access-Control-Allow-Origin", "*");
@@ -43,7 +43,7 @@ const FileRoute = function(app, headerDB, riseDisplayNetworkII, config, logger) 
           controller.isStale(config.fileUpdateDuration, (err, stale) => {
 
             if (err) {
-              logger.error(err, fileUrl);
+              logger.error(err, null, fileUrl);
             }
 
             if (stale) {
@@ -54,18 +54,18 @@ const FileRoute = function(app, headerDB, riseDisplayNetworkII, config, logger) 
 
                   // get the appropriate header field for request
                   controller.getUpdateHeaderField((err, field) => {
-                    if (err) { logger.error(err, fileUrl); }
+                    if (err) { logger.error(err, null, fileUrl); }
 
                     controller.on("downloaded", () => {
-                      logger.info("File downloaded - " + fileUrl);
+                      logger.info("File downloaded", fileUrl);
                     });
 
                     controller.on("request-error", (err) => {
-                      logger.error(err, fileUrl);
+                      logger.error(err, null, fileUrl);
                     });
 
                     controller.on("move-file-error", (err) => {
-                      logger.error(err, fileUrl);
+                      logger.error(err, null, fileUrl);
                     });
 
                     // Make request to download file passing request header
@@ -88,7 +88,7 @@ const FileRoute = function(app, headerDB, riseDisplayNetworkII, config, logger) 
                 // Download the file.
                 if (availableSpace > config.diskThreshold) {
                   controller.on("downloaded", () => {
-                    logger.info("File downloaded - " + fileUrl);
+                    logger.info("File downloaded", fileUrl);
                   });
 
                   controller.on("downloading", () => {
@@ -100,16 +100,16 @@ const FileRoute = function(app, headerDB, riseDisplayNetworkII, config, logger) 
                   });
 
                   controller.on("request-error", (err) => {
-                    logger.error(err, fileUrl);
+                    logger.error(err, null, fileUrl);
                     sendResponse(res, 504, "File's host server could not be reached", fileUrl);
                   });
 
                   controller.on("move-file-error", (err) => {
-                    logger.error(err, fileUrl);
+                    logger.error(err, null, fileUrl);
                   });
 
                   controller.on("delete-file-error", (err) => {
-                    logger.error(err, fileUrl);
+                    logger.error(err, null, fileUrl);
                   });
 
                   controller.downloadFile();
@@ -130,11 +130,11 @@ const FileRoute = function(app, headerDB, riseDisplayNetworkII, config, logger) 
 
   function getFromCache(req, res, controller, fileUrl, headers) {
     controller.streamFile(req, res, headers);
-    logger.info("File exists in cache. Not downloading - " + fileUrl);
+    logger.info("File exists in cache. Not downloading", fileUrl);
   }
 
   function sendInvalidResponseResponse(res, fileUrl, statusCode) {
-    logger.error("Invalid response with status code " + statusCode + " - " + fileUrl);
+    logger.error("Invalid response with status code " + statusCode, null, fileUrl);
 
     if (statusCode === 404) {
       sendResponse(res, 534, "File not found on the host server", fileUrl);
@@ -145,7 +145,7 @@ const FileRoute = function(app, headerDB, riseDisplayNetworkII, config, logger) 
 
   function sendDownloadingResponse(res, fileUrl) {
     sendResponse(res, 202, "File is downloading", fileUrl);
-    logger.info("File is downloading - " + fileUrl);
+    logger.info("File is downloading", fileUrl);
   }
 
   function sendResponse(res, statusCode, message, fileUrl) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-cache-v2",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Rise Cache for Rise Player",
   "main": "rise-cache.js",
   "scripts": {

--- a/test/integration/file-test.js
+++ b/test/integration/file-test.js
@@ -213,7 +213,7 @@ describe("/files endpoint", () => {
           .get("/files")
           .query({ url: "http://example.com/logo.png" })
           .end((err, res) => {
-            expect(spy.calledWith("Invalid response with status code 403 - http://example.com/logo.png")).to.be.true;
+            expect(spy.calledWith("Invalid response with status code 403", null, "http://example.com/logo.png")).to.be.true;
             logger.error.restore();
 
             done();
@@ -533,7 +533,7 @@ describe("/files endpoint", () => {
         .get("/files")
         .query({ url: "http://example.com/logo.png" })
         .end(() => {
-          expect(spy.calledWith("No headers available", "http://example.com/logo.png"));
+          expect(spy.calledWith("No headers available", null, "http://example.com/logo.png"));
           logger.error.restore();
           done();
         });

--- a/test/unit/helpers/logger/external-logger-bigquery-test.js
+++ b/test/unit/helpers/logger/external-logger-bigquery-test.js
@@ -16,7 +16,8 @@ describe("External Logger", () => {
 
   let bqClientInsertSpy, fileSystemAppendToLogSpy;
   let fileSystem = {
-    appendToLog : function (logDatetime, message) { return;}
+    appendToLog : function (logDatetime, message) { return;},
+    getFileName: function (url) {return "";}
   };
 
   before( function () {
@@ -42,10 +43,12 @@ describe("External Logger", () => {
       display_id: displayId,
       cache_version: version,
       os: os,
-      ts: date.toISOString()
+      ts: date.toISOString(),
+      file_url: "",
+      file_name: ""
     };
 
-    externalLogger.log(data.event, data.event_details, data.error_details, date);
+    externalLogger.log(data.event, data.event_details, undefined, undefined, data.error_details, date);
 
     expect(bqClientInsertSpy.calledWith("events", data, date, "20160920")).to.be.true;
 
@@ -77,11 +80,13 @@ describe("External Logger", () => {
       display_id: displayId,
       cache_version: version,
       os: os,
-      ts: date.toISOString()
+      ts: date.toISOString(),
+      file_url: "",
+      file_name: ""
     };
     let logDatetime = "logDatetime";
 
-    externalLogger.log(data.event, data.event_details, data.error_details, date, logDatetime);
+    externalLogger.log(data.event, data.event_details, undefined, undefined, data.error_details, date, logDatetime);
 
     expect(bqClientInsertSpy.calledWith("events", data, date, "20160920")).to.be.true;
 

--- a/test/unit/helpers/logger/logger-test.js
+++ b/test/unit/helpers/logger/logger-test.js
@@ -11,7 +11,8 @@ describe("Logger", () => {
     log: function (event, event_details, error_details, date) {}
   };
   let fileSystem = {
-    appendToLog: function (datetime, message) {}
+    appendToLog: function (datetime, message) {},
+    getFileName: function (url) {return "";}
   };
   let debugging = true;
   let dateString = "2016/09/20 00:00:00";
@@ -67,7 +68,7 @@ describe("Logger", () => {
 
       expect(consoleErrorSpy.calledWith(dateString + " - " + message)).to.be.true;
 
-      expect(externalLoggerLogSpy.calledWith("error", detail, errorDetails)).to.be.true;
+      expect(externalLoggerLogSpy.calledWith("error", detail, undefined, undefined, errorDetails)).to.be.true;
 
       expect(fileSystemAppendToLogSpy.calledWith(dateString, message)).to.be.true;
 
@@ -131,7 +132,7 @@ describe("Logger", () => {
 
       expect(consoleErrorSpy.calledWith(dateString + " - " + message)).to.be.false;
 
-      expect(externalLoggerLogSpy.calledWith("error", detail, errorDetails)).to.be.true;
+      expect(externalLoggerLogSpy.calledWith("error", detail, undefined, undefined, errorDetails)).to.be.true;
 
       expect(fileSystemAppendToLogSpy.calledWith(dateString, message)).to.be.true;
 
@@ -197,7 +198,7 @@ describe("Logger", () => {
 
       expect(consoleErrorSpy.calledWith(dateString + " - " + message)).to.be.false;
 
-      expect(externalLoggerLogSpy.calledWith("error", detail, errorDetails)).to.be.false;
+      expect(externalLoggerLogSpy.calledWith("error", detail, undefined, undefined, errorDetails)).to.be.false;
 
       expect(fileSystemAppendToLogSpy.calledWith(dateString, message)).to.be.true;
 

--- a/test/unit/helpers/logger/logger-test.js
+++ b/test/unit/helpers/logger/logger-test.js
@@ -47,7 +47,7 @@ describe("Logger", () => {
       consoleWarnSpy.restore();
     });
 
-    it("should log an info event", () => {
+    it("should log an info event with no file details", () => {
       let detail = "test info";
       let message = "INFO: " + detail;
       logger.info(detail);
@@ -60,7 +60,23 @@ describe("Logger", () => {
 
     });
 
-    it("should log an error event", () => {
+    it("should log an info event with file details", () => {
+      let detail = "test info";
+      let url = "http://test.com/image.jpg";
+      let name = "cdf42c077fe6037681ae3c003550c2c5";
+      let message = `INFO: ${detail} ${url} ${name}`;
+
+      logger.info(detail, url, name);
+
+      expect(consoleInfoSpy.calledWith(dateString + " - " + message)).to.be.true;
+
+      expect(externalLoggerLogSpy.calledWith("info", detail, url, name)).to.be.true;
+
+      expect(fileSystemAppendToLogSpy.calledWith(dateString, message)).to.be.true;
+
+    });
+
+    it("should log an error event with no file details", () => {
       let detail = "test error";
       let errorDetails = "exception 1";
       let message = "ERROR: " + detail + " " + errorDetails;
@@ -74,7 +90,24 @@ describe("Logger", () => {
 
     });
 
-    it("should log a warn event", () => {
+    it("should log an error event with file details", () => {
+      let detail = "test error";
+      let errorDetails = "exception 1";
+      let url = "http://test.com/image.jpg";
+      let name = "cdf42c077fe6037681ae3c003550c2c5";
+      let message = `ERROR: ${detail} ${errorDetails} ${url} ${name}`;
+
+      logger.error(detail, errorDetails, url, name);
+
+      expect(consoleErrorSpy.calledWith(dateString + " - " + message)).to.be.true;
+
+      expect(externalLoggerLogSpy.calledWith("error", detail, url, name, errorDetails)).to.be.true;
+
+      expect(fileSystemAppendToLogSpy.calledWith(dateString, message)).to.be.true;
+
+    });
+
+    it("should log a warn event with no file details", () => {
       let detail = "test warn";
       let message = "WARNING: " + detail;
       logger.warn(detail);
@@ -82,6 +115,22 @@ describe("Logger", () => {
       expect(consoleWarnSpy.calledWith(dateString + " - " + message)).to.be.true;
 
       expect(externalLoggerLogSpy.calledWith("warning", detail)).to.be.true;
+
+      expect(fileSystemAppendToLogSpy.calledWith(dateString, message)).to.be.true;
+
+    });
+
+    it("should log a warn event with file details", () => {
+      let detail = "test warn";
+      let url = "http://test.com/image.jpg";
+      let name = "cdf42c077fe6037681ae3c003550c2c5";
+      let message = `WARNING: ${detail} ${url} ${name}`;
+
+      logger.warn(detail, url, name);
+
+      expect(consoleWarnSpy.calledWith(dateString + " - " + message)).to.be.true;
+
+      expect(externalLoggerLogSpy.calledWith("warning", detail, url, name)).to.be.true;
 
       expect(fileSystemAppendToLogSpy.calledWith(dateString, message)).to.be.true;
 

--- a/test/unit/jobs/cleanup-test.js
+++ b/test/unit/jobs/cleanup-test.js
@@ -149,6 +149,9 @@ describe("Delete unused files", () => {
     it("should log info when file deleted", (done) => {
       setTimeout(function() {
         expect(spy.getCall(1).args[0]).to.equal("File deleted");
+        expect(spy.getCall(1).args[1]).to.be.string;
+        expect(spy.getCall(1).args[1]).to.not.be.empty;
+        expect(spy.getCall(1).args[2]).to.equal("cdf42c077fe6037681ae3c003550c2c5");
 
         done();
       }, 200);
@@ -157,6 +160,9 @@ describe("Delete unused files", () => {
     it("should log info when file headers deleted", (done) => {
       setTimeout(function() {
         expect(spy.getCall(2).args[0]).to.equal("File headers deleted");
+        expect(spy.getCall(2).args[1]).to.be.string;
+        expect(spy.getCall(2).args[1]).to.not.be.empty;
+        expect(spy.getCall(2).args[2]).to.equal("cdf42c077fe6037681ae3c003550c2c5");
 
         done();
       }, 200);
@@ -165,6 +171,9 @@ describe("Delete unused files", () => {
     it("should log info when file metadata deleted", (done) => {
       setTimeout(function() {
         expect(spy.getCall(3).args[0]).to.equal("File metadata deleted");
+        expect(spy.getCall(3).args[1]).to.be.string;
+        expect(spy.getCall(3).args[1]).to.not.be.empty;
+        expect(spy.getCall(3).args[2]).to.equal("cdf42c077fe6037681ae3c003550c2c5");
 
         done();
       }, 200);


### PR DESCRIPTION
- Logger and BQ logger now provide file url and file name params
- BQ logger will use the md5 hash file name via the file url value if a name is not provided
- All logger instances revised to include file url and file name if applicable
- Unit and integration tests revised and added
- Minor patch version bump