### PR TITLE
Fix missing Content-Type in headers.db

### DIFF
--- a/app/controllers/file.js
+++ b/app/controllers/file.js
@@ -59,8 +59,9 @@ FileController.prototype.downloadFile = function(opts) {
           this.emit("downloading");
         }
         else if (res.statusCode == 304) {
-          this.saveHeaders(res.headers);
-        } else {
+          this.updateTimestamp();
+        }
+        else {
           this.emit("invalid-response", res.statusCode);
         }
       })
@@ -165,6 +166,19 @@ FileController.prototype.getTimestampData = function(cb) {
       createdAt: newHeader.data.createdAt,
       updatedAt: newHeader.data.updatedAt
     });
+  });
+};
+
+FileController.prototype.updateTimestamp = function() {
+  this.header.set("key", this.fileName);
+
+  // Update the key field to automatically trigger a timestamp update.
+  this.header.update({ "key": this.fileName }, (err, numAffected) => {
+    if (err) {
+      return this.emit("timestamp-error", err);
+    }
+
+    this.emit("timestamp-updated", numAffected);
   });
 };
 

--- a/app/models/data.js
+++ b/app/models/data.js
@@ -31,6 +31,17 @@ Data.prototype.save = function(callback) {
   });
 };
 
+/* Update a particular field of the document. */
+Data.prototype.update = function(field, callback) {
+  this.db.update({ key: this.data.key }, { $set: field }, {}, (err, numAffected) => {
+    if (err) {
+      return callback(err);
+    }
+
+    callback(null, numAffected);
+  });
+};
+
 Data.prototype.delete = function (key, callback) {
   this.db.remove({ key: key }, {}, (err, numRemoved) => {
     if (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-cache-v2",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Rise Cache for Rise Player",
   "main": "rise-cache.js",
   "scripts": {

--- a/test/unit/controllers/file-test.js
+++ b/test/unit/controllers/file-test.js
@@ -109,14 +109,12 @@ describe("FileController", () => {
       });
     });
 
-    it("should save headers when response is 304", (done) => {
+    it("should update timestamp when response is 304", (done) => {
       let header = {
-        save: function (cb) {
-          cb(null, {});
+        update: function (field, cb) {
+          cb(null, 1);
         },
-        set: function () {
-
-        }
+        set: function () {}
       };
 
       fileController = new FileController("http://abc123.com/logo.png", header, riseDisplayNetworkII);
@@ -127,8 +125,8 @@ describe("FileController", () => {
 
       fileController.downloadFile();
 
-      fileController.on("headers", () => {
-        expect(true).to.be.true;
+      fileController.on("timestamp-updated", (numAffected) => {
+        expect(numAffected).to.equal(1);
         done();
       });
 


### PR DESCRIPTION
The _headers.db_ file is sometimes missing the _Content-Type_ header for a file. It gets into this state when it receives a 304 and re-saves the headers, only the header data is incomplete.

A file that is missing the _Content-Type_ header is automatically given a _Content-Type_ of _application/octet-stream_, which tells the browser to try to save it to a file. This results in the image / video not being visible on a Display.

To fix, don't re-save the headers. Instead, re-save the key which automatically updates the _updatedAt_ timestamp.

Fixes #74.