### PR TITLE
Fix cause of uncaughtException

### DIFF
--- a/app/controllers/file.js
+++ b/app/controllers/file.js
@@ -117,7 +117,7 @@ FileController.prototype.writeFile = function(res) {
       }
     });
   }).on("error", (err) => {
-    fs.unlink(this.pathInDownload);
+    this.deleteFileFromDownload();
     this.emit("file-error", err);
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-cache-v2",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Rise Cache for Rise Player",
   "main": "rise-cache.js",
   "scripts": {


### PR DESCRIPTION
- Use `deleteFileFromDownload()` function to check for existence of file and handle deletion failure
- Version bump