### PR TITLE
Use rise cache os proxy from player

### DIFF
--- a/app/controllers/file.js
+++ b/app/controllers/file.js
@@ -43,7 +43,9 @@ FileController.prototype.downloadFile = function(opts) {
       "User-Agent": "request"
     };
 
-    options.proxy = (this.riseDisplayNetworkII) ? this.riseDisplayNetworkII.get("activeproxy"): null;
+    options.proxy = (this.riseDisplayNetworkII) ?
+    (this.riseDisplayNetworkII.get("activeproxy") || this.riseDisplayNetworkII.get("rcosproxy")) :
+    null;
 
     options.timeout = config.requestTimeout;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-cache-v2",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Rise Cache for Rise Player",
   "main": "rise-cache.js",
   "scripts": {


### PR DESCRIPTION
At startup player will resolve a proxy lookup using the default session
and save the result in the ini file. This is separate from a proxy that
users might have manually configured in activeproxy. Manually configured
proxy will take precedence.