### PR TITLE
Check if risecache.log exists before truncating

### DIFF
--- a/app/helpers/file-system.js
+++ b/app/helpers/file-system.js
@@ -150,9 +150,13 @@ module.exports = {
   },
 
   cleanupLogFile: function(logger) {
-    fs.truncate(config.logFilePath, 0, (err) => {
-      if (err) {
-        logger.error(err);
+    this.fileExists(config.logFilePath, (exists) => {
+      if ( exists ) {
+        fs.truncate(config.logFilePath, 0, (err) => {
+          if (err) {
+            logger.error(err);
+          }
+        });
       }
     });
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-cache-v2",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "lockfileVersion": 1,
   "dependencies": {
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-cache-v2",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Rise Cache for Rise Player",
   "main": "rise-cache.js",
   "scripts": {

--- a/test/unit/helpers/file-system-test.js
+++ b/test/unit/helpers/file-system-test.js
@@ -351,6 +351,18 @@ describe("cleanupLogFile", () => {
 
   });
 
+  it("should not log error if file does not exist", (done) => {
+    let spy = sinon.spy(logger, "error");
+
+    fileSystem.cleanupLogFile(logger);
+
+    setTimeout(function() {
+      expect(spy.callCount).to.equal(0);
+      logger.error.restore();
+      done();
+    }, 200);
+  });
+
   it("should log an error if the log could not be cleaned up", (done) => {
     let spy = sinon.spy(logger, "error");
 


### PR DESCRIPTION
- Preventing unnecessary error log to BQ when cleaning up rise risecache.log file but it doesn't exist yet