### PR TITLE
Add SIGPIPE handler 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,3 @@ workflows:
   test_and_publish:
     jobs:
       - "test"
-      - "publish_to_npm":
-          requires:
-            - test
-          filters:
-            branches:
-              only:
-                - master

--- a/app/app.js
+++ b/app/app.js
@@ -41,6 +41,8 @@ const AppFactory = function() {
         }
       });
 
+      process.on("SIGPIPE", () => logger.info("SIGPIPE received"));
+
       if (!exists) {
         logger.warn("RiseDisplayNetworkIIPath.ini file not found");
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-cache-v2",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-cache-v2",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "description": "Rise Cache for Rise Player",
   "main": "rise-cache.js",
   "scripts": {


### PR DESCRIPTION
## Description
Add a handler to SIGPIPE to avoid crashing

## Motivation and Context
Why is this change required? What problem does it solve?

Rise Cache started crashing more frequently with player running the new electron version because the Node version embedded in electron does not ignore SIGPIPE as the old version did. This is causing RC to crash and was causing player to crash because of https://github.com/Rise-Vision/rise-launcher-electron/issues/824 .

This change includes a handler to SIGPIPE to avoid the process crashing. 

## How Has This Been Tested?
Tested manually with a staged version of player

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
