### PR TITLE
Update version to 1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-cache-v2",
-  "version": "1.7.10",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-cache-v2",
-  "version": "1.7.10",
+  "version": "1.8.0",
   "description": "Rise Cache for Rise Player",
   "main": "rise-cache.js",
   "scripts": {


### PR DESCRIPTION
## Description
Update Rise Cache version to not use double digits in the last part.

## Motivation and Context
Why is this change required? What problem does it solve?
This change fixes https://github.com/Rise-Vision/rise-launcher-electron/issues/831 that is caused because the [`_compareVersionNumbers`  in widget-common](https://github.com/Rise-Vision/widget-common/blob/master/src/js/rise-cache.js#L100) doesn't work well when there's more than one digit in the version parts.

## How Has This Been Tested?
Tested manually by updating player on stage and having a presentation set up with Image Widgets pointing to external URLs.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
